### PR TITLE
Added nap_time config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The format of the configuration file is the same as `postgresql.conf`.
 - `job_queue_interval`: poll interval of the jobs queue. Default 5 seconds.
 - `job_queue_processes`: Maximum number of job processed at the same time.
    Default `1000`.
+- `nap_time`: Time to wait in the main loop before each run. Default `100ms`
 
 ### Database
 
@@ -182,6 +183,8 @@ log_truncate_on_rotation=0
 job_queue_interval=5
 #Maximum number of job processed at the same time
 job_queue_processes=1000
+# Time to wait in the main loop before each run (to free some CPU resources)
+nap_time = 0.1
 
 #-----------
 #  Database

--- a/bin/pg_dbms_job
+++ b/bin/pg_dbms_job
@@ -546,12 +546,8 @@ sub read_config
 			}
 			elsif ($var eq 'job_queue_interval')
 			{
-				$val = int($val);
-				if ($job_queue_interval != $val)
-				{
-					$job_queue_interval = $val;
-					dprint('LOG', "Setting job_queue_interval from configuration file to $job_queue_interval");
-				}
+				$job_queue_interval = $val;
+				dprint('LOG', "Setting job_queue_interval from configuration file to $job_queue_interval");
 			}
 			elsif ($var eq 'job_queue_processes')
 			{
@@ -561,6 +557,11 @@ sub read_config
 					$job_queue_processes = $val;
 					dprint('LOG', "Setting job_queue_processes from configuration file to $job_queue_processes");
 				}
+			}
+			elsif ($var eq 'nap_time')
+			{
+				$naptime = $val;
+				dprint('LOG', "Setting nap_time from configuration file to $naptime");
 			}
 			elsif ($var =~ /^(host|database|user|passwd|port)$/)
 			{

--- a/etc/pg_dbms_job.conf
+++ b/etc/pg_dbms_job.conf
@@ -16,6 +16,8 @@ log_truncate_on_rotation=0
 job_queue_interval=5
 # Maximum number of job processed at the same time
 job_queue_processes=1000
+# Time to wait in the main loop before each run (to free some CPU resources)
+nap_time = 0.1
 
 #-----------
 #  Database


### PR DESCRIPTION
- New config parameter was added `nap_time`  (now it is possible to control for how long we should wait in the main loop between iterations)
- Added ability to specify decimal values for `job_queue_interval`