### PR TITLE
More precise calculation of `next_date`

### DIFF
--- a/bin/pg_dbms_job
+++ b/bin/pg_dbms_job
@@ -254,7 +254,7 @@ my $previous_scheduled_exec = 0;
 while (!$fini)
 {
 	# Stores loop start time
-	my $t0 = time;
+	my $t0 = Time::HiRes::time;
 
 	####
 	# look if there are some child processes dead to register
@@ -326,7 +326,7 @@ while (!$fini)
 	{
 		%ASYNC_JOBS = get_async_jobs($async_count);
 		# Register last execution time
-		$previous_async_exec = time;
+		$previous_async_exec = Time::HiRes::time;
 	}
 
 	####
@@ -337,7 +337,7 @@ while (!$fini)
 	{
 		%SCHEDULED_JOBS = get_scheduled_jobs();
 		# Register last execution time
-		$previous_scheduled_exec = time;
+		$previous_scheduled_exec = Time::HiRes::time;
 		# If we lost the connection 
 		if ($config_invalidated) {
 			sleep(3);
@@ -945,7 +945,7 @@ sub subprocess_asynchronous_jobs
 		my $errstr = '';
 		my $status = '';
 		my $sqlstate = '';
-		my $t0 = time;
+		my $t0 = Time::HiRes::time;
 
 		my $codetoexec = qq{DO \$pg_dbms_job\$
 DECLARE
@@ -983,7 +983,7 @@ END;
 		}
 		delete_job($ldbh, $jobid);
 
-		my $t1 = time;
+		my $t1 = Time::HiRes::time;
 		# Store the execution result in table all_job_run_details
 		my @ret = store_job_execution_details(  $ldbh, $ASYNC_JOBS{ $jobid }{ 'log_user' },
 							$jobid, $start_t, $t1 - $t0,
@@ -1052,7 +1052,7 @@ sub subprocess_scheduled_jobs
 
 	if (defined $ldbh)
 	{
-		my $t0 = time;
+		my $t0 = Time::HiRes::time;
 
 		# Set application name to pg_dbms_job:jobid
 		if (not $ldbh->do("SET application_name TO 'pg_dbms_job:scheduled:$jobid'"))
@@ -1137,7 +1137,7 @@ END;
 			}
 			else
 			{
-				my $t1 = time;
+				my $t1 = Time::HiRes::time;
 				my $timediff = $t1 - $t0;
 				# Update the begin execution date for this job and the total
 				# number of times that the job has failed to complete since
@@ -1163,7 +1163,7 @@ END;
 			}
 		}
 
-		my $t1 = time;
+		my $t1 = Time::HiRes::time;
 
 		my $timediff = $t1 - $t0;
 		# Update the begin execution date for this job, the last successful execution date

--- a/sql/pg_dbms_job--1.5.0.sql
+++ b/sql/pg_dbms_job--1.5.0.sql
@@ -13,7 +13,7 @@ CREATE TABLE dbms_job.all_scheduled_jobs (
         last_sec text, -- same as last_date (not used)
         this_date timestamp with time zone, -- date that this job started executing, null when the job is not running
         this_sec text, -- same as this_date (not used)
-        next_date timestamp(0) with time zone NOT NULL, -- date that this job will next be executed
+        next_date timestamp with time zone NOT NULL, -- date that this job will next be executed
         next_sec timestamp with time zone, -- same as next_date (not used)
         total_time interval, -- total wall clock time spent by the system on this job, in seconds
         broken boolean DEFAULT false, -- true: no attempt is made to run this job, false: an attempt is made to run this job
@@ -93,7 +93,7 @@ CREATE POLICY dbms_job_policy ON dbms_job.all_scheduler_job_run_details USING (o
 CREATE PROCEDURE dbms_job.broken(
 		jobid     IN  bigint,
 		broken    IN  boolean,
-		next_date IN  timestamp(0) with time zone DEFAULT current_timestamp)
+		next_date IN  timestamp with time zone DEFAULT current_timestamp)
     LANGUAGE PLPGSQL
     AS $$
 BEGIN
@@ -115,7 +115,7 @@ REVOKE ALL ON PROCEDURE dbms_job.broken FROM PUBLIC;
 CREATE PROCEDURE dbms_job.change(
 		job          IN  bigint,
 		what         IN  text,
-		next_date    IN  timestamp(0) with time zone,
+		next_date    IN  timestamp with time zone,
 		job_interval IN  text,
 		instance     IN  bigint DEFAULT 0,
 		force        IN  boolean DEFAULT false)
@@ -186,7 +186,7 @@ REVOKE ALL ON PROCEDURE dbms_job.interval FROM PUBLIC;
 
 CREATE PROCEDURE dbms_job.next_date(
 		jobid        IN  bigint,
-		next_date  IN  timestamp(0) with time zone)
+		next_date  IN  timestamp with time zone)
     LANGUAGE PLPGSQL
     AS $$
 BEGIN
@@ -286,7 +286,7 @@ REVOKE ALL ON PROCEDURE dbms_job.run FROM PUBLIC;
 CREATE FUNCTION dbms_job.submit(
 		jobid         OUT   bigint,
 		what          IN    text,
-		next_date     IN    timestamp(0) with time zone DEFAULT current_timestamp,
+		next_date     IN    timestamp with time zone DEFAULT current_timestamp,
 		job_interval  IN    text DEFAULT NULL,
 		no_parse      IN    boolean DEFAULT false)
     RETURNS bigint
@@ -390,11 +390,11 @@ CREATE TRIGGER dbms_job_async_notify_trg
     FOR STATEMENT EXECUTE FUNCTION dbms_job.job_async_notify();
 
 CREATE FUNCTION dbms_job.get_next_date(text)
-    RETURNS timestamp(0) with time zone
+    RETURNS timestamp with time zone
     LANGUAGE PLPGSQL
     AS $$
 DECLARE
-    next_date timestamp(0) with time zone;
+    next_date timestamp with time zone;
 BEGIN
 	EXECUTE 'SELECT '||$1 INTO next_date;
 	RETURN next_date;


### PR DESCRIPTION
- `timestamp(0)` has been replaced with `timestamp` to support more precise calculation of `next_date`
- `time` function has been replaced with `Time::HiRes::time` so that we can use more precise polling intervals if required